### PR TITLE
README.md: add SDK meeting info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,26 @@
-Operator Framework Community
-============================
+# Operator Framework Community
 
 This repository contains community process, charter, and coordination documents for the Operator Framework Project,
 
 Designs, technical proposals, and issues are tracked in the [operator-sdk repo](https://github.com/operator-framework/operator-sdk/tree/master/doc) and [operator-lifeycle-manager repo](https://github.com/operator-framework/operator-lifecycle-manager/tree/master/doc/design).
 
-Get involved
-------------
+## Get involved
 
 Discuss on:
 * [Kubernetes Slack in #kubernetes-operators](https://kubernetes.slack.com) ([Get invite](https://slack.k8s.io))
 * [Operator Framework on Google Groups](https://groups.google.com/forum/#!forum/operator-framework)
 * [Operator Framework Commons SIG](https://commons.openshift.org/sig/OpenshiftOperators.html)
 
-Operator Framework Special Interest Group Meetings
------------------------------------------
+## Meetings
+
+### Operator Framework Special Interest Group
 
 * Next Scheduled Meeting: November 12 2019  16:00 UTC/9:00 am Pacfic/Noon Eastern [dial-in details](https://github.com/operator-framework/community/projects/2#card-27939134)
-* [Proposed Agenda](https://github.com/operator-framework/community/projects)
-* [Propose an agenda topic propose](https://github.com/operator-framework/community/projects/2#column-6841651)
+  * [Proposed Agenda](https://github.com/operator-framework/community/projects)
+  * [Propose an agenda topic propose](https://github.com/operator-framework/community/projects/2#column-6841651)
   
-  
+### Operator SDK 
+
+* Wednesdays at 10:00 PT (Pacific Time) (monthly - fourth Wednesday every month). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
+  * [Meeting notes and Agenda](https://docs.google.com/document/d/1ujWb-rSJ4JWeHLVxK0WS5ZuSJgeESG42MDeYjSl9Q6U/edit#)
+  * Meeting recordings (coming soon!)


### PR DESCRIPTION
Add meeting info for a monthly SDK community meeting:

> * Wednesdays at 10:00 PT (Pacific Time) (monthly - fourth Wednesday every month). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
>   * [Meeting notes and Agenda](https://docs.google.com/document/d/1ujWb-rSJ4JWeHLVxK0WS5ZuSJgeESG42MDeYjSl9Q6U/edit#)
>   * Meeting recordings (coming soon!)