### PR TITLE
code-of-conduct.md: link to CNCF code of conduct and add contact info

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,6 @@
+# Operator Framework Community Code of Conduct
+
+Operator Framework follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting
+a [community chair](./GOVERNANCE.md#operations) or the CNCF mediator noted in the code of conduct document linked above.


### PR DESCRIPTION
* code-of-conduct.md: link to CNCF code of conduct add contact instructions

