### PR TITLE
Add some words on how to edit the olm meeting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ To organize and steer the development of projects that enable teams to manage th
     * [Agenda](https://docs.google.com/document/d/1Zuv-BoNFSwj10_zXPfaS9LWUQUCak2c8l48d0-AhpBw/edit)
     * [Meeting recordings](https://www.youtube.com/playlist?list=PLEcO8aSeUjeXDvBtPlaAvPTaknPR0Uwi-).
 
+**NOTE:** To obtain *edit* access to the agenda documents please join our [Google Group](https://groups.google.com/g/operator-framework-olm-dev) - ensure you are logged in to google docs with the same account you used to sign up to the Google Group.
+
 ### Organizers
 
 * Alexander Greene (**[@awgreene](https://github.com/awgreene)**), Red Hat


### PR DESCRIPTION
Signed-off-by: perdasilva <perdasilva@redhat.com>

### Motivation
I couldn't edit the agenda doc for today's WG meeting and was trying to figure out how to get access.
Eventually, I discovered the BIG RED TEXT on the document that said I must join the olm google group (which I already had).
Still, the problem was with the nut behind the keyboard. I was logged in with my personal account.

Anyway, I thought since this is the landing page, even though we already say it in BIG RED TEXT, we could also add this info there as well for extra Oomph