### PR TITLE
Add subproject maintainers to OWNERS of community

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -44,7 +44,7 @@ A dedicated git repository will be the authoritative archive for membership list
 The mailing list at groups.google.com/forum/#!forum/operator-framework will be used as a place to call for and publish group decisions, and to hold discussions in general.
 
 ### Operator Framework Community Membership
-All active members of the Operator Framework community are listed in the [`OWNERS`][OWNERS_ALIASES].
+All active members of the Operator Framework community are listed in the [`OWNERS`][OWNERS_ALIASES] or in the OWNERS files in Operator Framework subprojects.
 
 New members can apply for membership by creating an Issue or Pull Request on the repository on GitHub indicating their desire to join.
 

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,3 +1,8 @@
 approvers:
   - community-maintainers
   - community-chairs
+  - olm-approvers
+  - olm-reviewers
+  - operator-sdk-admins
+  - operator-sdk-approvers
+  - operator-sdk-reviewers


### PR DESCRIPTION
This gives subproject maintainers the right to vote in community
elections, governance updates, and Calls for Agreement.

Signed-off-by: Austin Macdonald <austin@redhat.com>

This change is substantive enough to require a Governance update vote. According to the [governance document](https://github.com/operator-framework/community/blob/master/GOVERNANCE.md#charter-and-governing-documents) we will follow these steps:

1. A public notice of 14 days is required before voting begins. I will initiate this process by sending a link to this PR to the [operator framework mailing list](https://groups.google.com/forum/#!forum/operator-framework).
2. After discussion, voting will begin. Prior to this change, the "active maintainers" who are eligible to vote are listed in the [OWNERS](https://github.com/operator-framework/community/blob/master/OWNERS_ALIASES#L16-L28) file.
    - asmacdo
    - awgreene 
    - dmesser
    - dmueller2001
    - ecordell
    - gallettilance
    - gerred
    - jberkhahn
    - joelanford
    - jmrodri
    - tlwu2013

For the vote to succeed:

- A quorum of at least 51% of active Operator Framework Community Members must vote.
- A quorum of 3 Chairs is needed
- Two-thirds of the voting quorum must approve the proposal.
- A majority of Chairs must approve the proposal.